### PR TITLE
Done wit everything lol

### DIFF
--- a/src/main/java/Problem3/Book.java
+++ b/src/main/java/Problem3/Book.java
@@ -18,6 +18,15 @@ public abstract class Book implements StoreMediaOperations {
         this.title = anotherBook.title;
         this.author = anotherBook.author;
     }
+    public void setID(UUID iD){
+        this.id = iD;
+    }
+    public void setTitle(String t){
+        this.title = t;
+    }
+    public void setAuthor(String a){
+        this.author = a;
+    }
 
     @Override
     public boolean equals(Object obj) {
@@ -37,11 +46,9 @@ public abstract class Book implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherBook.id) &&
-                author.equals(theOtherBook.author) &&
-                title.equals(theOtherBook.title);
+        //return id.equals(theOtherBook.id) && author.equals(theOtherBook.author) && title.equals(theOtherBook.title);
 
         // fix is here
-        // return id.equals(theOtherBook.id);
+        return id.equals(theOtherBook.id);
     }
 }

--- a/src/main/java/Problem3/Movie.java
+++ b/src/main/java/Problem3/Movie.java
@@ -18,6 +18,15 @@ public abstract class Movie implements StoreMediaOperations {
         this.title = anotherMovie.title;
         this.id = anotherMovie.id;
     }
+    public void setID(UUID iD){
+        this.id = iD;
+    }
+    public void setTitle(String t){
+        this.title = t;
+    }
+    public void setRating(String r){
+        this.rating = r;
+    }
 
     @Override
     public boolean equals(Object obj) {
@@ -37,11 +46,9 @@ public abstract class Movie implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherMovie.id) &&
-                rating.equals(theOtherMovie.rating) &&
-                title.equals(theOtherMovie.title);
+        //return id.equals(theOtherMovie.id) && rating.equals(theOtherMovie.rating) && title.equals(theOtherMovie.title);
 
         // fix is here
-        //return this.id == ((Movie) obj).id;
+        return this.id == ((Movie) obj).id;
     }
 }

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -1,17 +1,50 @@
 import Problem3.*;
 import org.junit.Test;
 
+import java.util.UUID;
+
 import static org.junit.Assert.*;
 
 public class Problem3Test {
     @Test
     public void catchTheBugInBook() {
         // quiz
+        UUID newID = UUID.randomUUID();
+
+        BookRomance lov = new BookRomance("t1", "au1");
+        BookRomance vol = new BookRomance(lov);
+
+        lov.setTitle("What is love, baby don't hurt me, don't hurt me, no more");
+        lov.setAuthor("Haddaway");
+
+        assertTrue(lov.equals(vol));
+
+        lov.setID(newID);
+
+        assertFalse(lov.equals(vol));
     }
 
     @Test
     public void catchTheBugInMovie() {
         // quiz
+        UUID newID1 = UUID.randomUUID();
+
+        MovieAction TI = new MovieAction("PG13", "TI-84");
+        MovieAction IT = new MovieAction(TI);
+
+        TI.setRating("GG");
+        TI.setTitle("2080 TI");
+
+        assertTrue(TI.equals(IT));
+        //Displays assertion error saying it is not true which is should be, should stay true since we didn't change the id
+        //if you use the old fix ;(
+        //but new fix  says its the same which is quality :)
+        TI.setID(newID1);
+
+        assertFalse(TI.equals(IT));
+
+        //now if i used my change id setter it should return true based on the the ids being different
+        //fails for the old and works for the new
     }
 
     // DO NOT REMOVE OR CHANGE ANYTHING BELOW THIS!


### PR DESCRIPTION
The reason why the bug came up was because it was comparing every part of the book or movie (title, author, rating, etc..). Not just the id which is what you said. So we created a setter to change the values of the everything individually. So to test the bug we changed only the title for example. If we used the bug it should result in an error. If we use the fix it would result a passed test since we didn't change the id. We can all change values and have the same id and it will result in an error with the bug since not all the values are the same now. All test pass regardless of the choice between fix or bug, except to catch the bug.